### PR TITLE
Wire up newsletter duplication action in SPA

### DIFF
--- a/app.js
+++ b/app.js
@@ -465,13 +465,50 @@ class MailingApp {
                 const data = await response.json();
                 this.currentNewsletter = data.newsletter;
                 this.newsletterSections = data.sections;
-                
+
                 document.getElementById('editorTitle').textContent = `Editor: ${data.newsletter.name}`;
                 this.switchView('newsletterEditor');
                 this.renderNewsletterEditor();
             }
         } catch (error) {
             this.showNotification('Error abriendo newsletter', 'error');
+        }
+    }
+
+    async duplicateNewsletter(newsletterId) {
+        if (!newsletterId) {
+            this.showNotification('Newsletter inválido para duplicar', 'error');
+            return;
+        }
+
+        try {
+            const response = await this.apiRequest(`/newsletters/${newsletterId}/duplicate`, {
+                method: 'POST'
+            });
+
+            let data = null;
+            try {
+                data = await response.json();
+            } catch (parseError) {
+                console.warn('⚠️ No se pudo parsear la respuesta de duplicación:', parseError);
+            }
+
+            if (!response.ok) {
+                const message = data?.error || 'Error duplicando newsletter';
+                this.showNotification(message, 'error');
+                return;
+            }
+
+            this.showNotification('Newsletter duplicado exitosamente', 'success');
+
+            await this.loadNewsletters();
+
+            if (data?.newsletter?.id) {
+                this.openNewsletterEditor(data.newsletter.id);
+            }
+        } catch (error) {
+            console.error('❌ Error duplicando newsletter:', error);
+            this.showNotification('Error duplicando newsletter', 'error');
         }
     }
 


### PR DESCRIPTION
## Summary
- implement the `duplicateNewsletter` UI handler so the SPA can call `POST /newsletters/:id/duplicate`
- refresh the list and open the duplicated newsletter after a successful response while showing notifications for failures

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb85d17c04832594b76ba3f96f89c6